### PR TITLE
number of rows (if last row does not totally fit in its width) was wrong

### DIFF
--- a/src/TilePlanner/Models/Rests.php
+++ b/src/TilePlanner/Models/Rests.php
@@ -69,7 +69,7 @@ final class Rests
         return self::$trash;
     }
 
-    public function getSumOfAll(): float
+    public function sumOfAll(): float
     {
         return array_sum($this->getRests(TilePlannerConstants::RESTS_LEFT)) + array_sum($this->getRests(TilePlannerConstants::RESTS_RIGHT)) + array_sum($this->getTrash());
     }

--- a/src/TilePlanner/TilePlanCreator.php
+++ b/src/TilePlanner/TilePlanCreator.php
@@ -24,7 +24,6 @@ final class TilePlanCreator
 
     public function create(TilePlanInput $tileInput): TilePlan
     {
-        // TODO validate input
         $plan = new TilePlan();
         $totalRows = $this->getTotalRows($tileInput);
 
@@ -36,7 +35,7 @@ final class TilePlanCreator
             );
 
             $plan->addRow($row);
-            $plan->setTotalTiles($this->getHighestTileNumberFromRow($row));
+            $plan->setTotalTiles($this->retrieveHighestTileNumberFromRow($row));
         }
 
         $plan->setTotalArea($tileInput->getRoomWidthWithGaps() * $tileInput->getRoomDepthWithGaps());
@@ -50,14 +49,14 @@ final class TilePlanCreator
                 $this->rests->getRests(TilePlannerConstants::RESTS_RIGHT)
             )
         );
-        $plan->setTotalRest($this->rests->getSumOfAll());
+        $plan->setTotalRest($this->rests->sumOfAll());
 
         return $plan;
     }
 
     private function getTotalRows(TilePlanInput $input): int
     {
-        return (int)floor(($input->getRoomDepth() / $input->getTileWidth()));
+        return (int)ceil(($input->getRoomDepth() / $input->getTileWidth()));
     }
 
     private function mergeTiles(array $tiles): array
@@ -75,7 +74,7 @@ final class TilePlanCreator
         return $mergedTrash;
     }
 
-    private function getHighestTileNumberFromRow(Row $row): int
+    private function retrieveHighestTileNumberFromRow(Row $row): int
     {
         $numbers = array_map(fn(Tile $tile) => $tile->getNumber(), $row->getTiles());
 

--- a/tests/Unit/TilePlanner/TilePlanCreatorTest.php
+++ b/tests/Unit/TilePlanner/TilePlanCreatorTest.php
@@ -37,16 +37,16 @@ final class TilePlanCreatorTest extends TestCase
         $creator = new TilePlanCreator($rowCreator, $rests);
 
         $tileInput = new TilePlanInput(
-            Room::create(100, 25),
+            Room::create(100, 90),
             Tile::create(25, 50),
             new LayingOptions(minTileLength: 20, costsPerSquare: 2)
         );
 
         $plan = $creator->create($tileInput);
 
-        self::assertCount(1, $plan->getRows());
-        self::assertEquals(2500, $plan->getTotalArea());
-        self::assertEquals(0.25, $plan->getTotalAreaInSquareMeter());
-        self::assertEquals(0.5, $plan->getTotalPrice());
+        self::assertCount(4, $plan->getRows());
+        self::assertEquals(9000, $plan->getTotalArea());
+        self::assertEquals(0.9, $plan->getTotalAreaInSquareMeter());
+        self::assertEquals(1.8, $plan->getTotalPrice());
     }
 }

--- a/tests/Unit/TilePlannerTest.php
+++ b/tests/Unit/TilePlannerTest.php
@@ -28,6 +28,6 @@ final class TilePlannerTest extends TestCase
         self::assertEquals('69000', $plan->getTotalArea());
         self::assertEquals('230', $plan->getRoomDepth());
         self::assertEquals('300', $plan->getRoomWidth());
-        self::assertCount(11, $plan->getRows());
+        self::assertCount(12, $plan->getRows());
     }
 }


### PR DESCRIPTION
last row was missing in most cases cause floor() is rounding fractions down 

before: roomWidth=30 and tileWidth:20 would end up in 1 row cause floor(30/20) is 1
after: ceil(30/20) is 2 ✔️ 