### PR TITLE
fix wrong numbers on tiles

### DIFF
--- a/src/Command/TilePlanCreatorCommand.php
+++ b/src/Command/TilePlanCreatorCommand.php
@@ -9,6 +9,7 @@ use TilePlanner\Shared\StringToFloatConverter;
 use TilePlanner\TilePlanner\Models\LayingOptions;
 use TilePlanner\TilePlanner\Models\Room;
 use TilePlanner\TilePlanner\Models\Tile;
+use TilePlanner\TilePlanner\Models\TileCounter;
 use TilePlanner\TilePlanner\TilePlannerFacade;
 use TilePlanner\TilePlanner\Models\TilePlanInput;
 use Gacela\Framework\DocBlockResolverAwareTrait;

--- a/src/TilePlanner/Creator/FirstTileCreator/ChessTileCreator.php
+++ b/src/TilePlanner/Creator/FirstTileCreator/ChessTileCreator.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace TilePlanner\TilePlanner\Creator\FirstTileCreator;
 
 use TilePlanner\TilePlanner\Creator\TileLengthRangeCreatorInterface;
+use TilePlanner\TilePlanner\Models\TileCounter;
 use TilePlanner\TilePlanner\TilePlannerConstants;
 use TilePlanner\TilePlanner\Models\TilePlan;
 use TilePlanner\TilePlanner\Models\TilePlanInput;
@@ -34,10 +35,18 @@ final class ChessTileCreator implements FirstTileCreatorInterface
         $tileRanges = $this->rangeCreator->calculateRanges($tileInput);
 
         if ($this->rangeValidator->isInRange($tileLength, $tileRanges->getRanges())) {
-            return Tile::create($tileInput->getTileWidth(), $tileLength);
+            return Tile::create(
+                $tileInput->getTileWidth(),
+                $tileLength,
+                TileCounter::next()
+            );
         }
 
-        $tile = Tile::create($tileInput->getTileWidth(), $tileRanges->getMinOfFirstRange());
+        $tile = Tile::create(
+            $tileInput->getTileWidth(),
+            $tileRanges->getMinOfFirstRange(),
+            TileCounter::next()
+        );
 
         $rests->addRest(
             $tileLength - $tileRanges->getMinOfFirstRange(),

--- a/src/TilePlanner/Creator/FirstTileCreator/FullTileCreator.php
+++ b/src/TilePlanner/Creator/FirstTileCreator/FullTileCreator.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace TilePlanner\TilePlanner\Creator\FirstTileCreator;
 
 use TilePlanner\TilePlanner\Creator\TileLengthRangeCreatorInterface;
+use TilePlanner\TilePlanner\Models\TileCounter;
 use TilePlanner\TilePlanner\TilePlannerConstants;
 use TilePlanner\TilePlanner\Models\TilePlan;
 use TilePlanner\TilePlanner\Models\TilePlanInput;
@@ -46,7 +47,11 @@ final class FullTileCreator implements FirstTileCreatorInterface
             )
             && $this->rangeValidator->isInRange($tileLength, $tileRanges->getRanges())
         ) {
-            return Tile::create($tileInput->getTileWidth(), $tileLength);
+            return Tile::create(
+                $tileInput->getTileWidth(),
+                $tileLength,
+                TileCounter::next(),
+            );
         }
 
         return null;

--- a/src/TilePlanner/Creator/FirstTileCreator/MaximumTileCreator.php
+++ b/src/TilePlanner/Creator/FirstTileCreator/MaximumTileCreator.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace TilePlanner\TilePlanner\Creator\FirstTileCreator;
 
 use TilePlanner\TilePlanner\Creator\TileLengthRangeCreatorInterface;
+use TilePlanner\TilePlanner\Models\TileCounter;
 use TilePlanner\TilePlanner\TilePlannerConstants;
 use TilePlanner\TilePlanner\Models\TilePlan;
 use TilePlanner\TilePlanner\Models\TilePlanInput;
@@ -35,7 +36,11 @@ final class MaximumTileCreator implements FirstTileCreatorInterface
         $maxLengthOfFirstRange = $tileRanges->getMaxOfFirstRange();
 
         if ($this->canUseMaxLengthOfFirstRange($plan, $tileInput, $tileRanges)) {
-            $tile = Tile::create($tileInput->getTileWidth(), $maxLengthOfFirstRange);
+            $tile = Tile::create(
+                $tileInput->getTileWidth(),
+                $maxLengthOfFirstRange,
+                TileCounter::next()
+            );
 
             $restOfTile = $tileLength - $maxLengthOfFirstRange;
 
@@ -53,8 +58,8 @@ final class MaximumTileCreator implements FirstTileCreatorInterface
     }
 
     private function canUseMaxLengthOfFirstRange(
-        TilePlan       $plan,
-        TilePlanInput  $tileInput,
+        TilePlan $plan,
+        TilePlanInput $tileInput,
         LengthRangeBag $tileRanges
     ): bool {
         if (

--- a/src/TilePlanner/Creator/FirstTileCreator/MinimumTileCreator.php
+++ b/src/TilePlanner/Creator/FirstTileCreator/MinimumTileCreator.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace TilePlanner\TilePlanner\Creator\FirstTileCreator;
 
 use TilePlanner\TilePlanner\Creator\TileLengthRangeCreatorInterface;
+use TilePlanner\TilePlanner\Models\TileCounter;
 use TilePlanner\TilePlanner\TilePlannerConstants;
 use TilePlanner\TilePlanner\Models\TilePlan;
 use TilePlanner\TilePlanner\Models\TilePlanInput;
@@ -42,7 +43,11 @@ final class MinimumTileCreator implements FirstTileCreatorInterface
             $tileMinLength,
             TilePlannerConstants::MIN_DEVIATION)
         ) {
-            $tile = Tile::create($tileInput->getTileWidth(), $minLengthOfFirstRange);
+            $tile = Tile::create(
+                $tileInput->getTileWidth(),
+                $minLengthOfFirstRange,
+                TileCounter::next()
+            );
             $rests->addRest(
                 $tileLength - $minLengthOfFirstRange,
                 $tileMinLength,

--- a/src/TilePlanner/Creator/FirstTileCreator/TileFromRestCreator.php
+++ b/src/TilePlanner/Creator/FirstTileCreator/TileFromRestCreator.php
@@ -6,6 +6,7 @@ namespace TilePlanner\TilePlanner\Creator\FirstTileCreator;
 
 use TilePlanner\TilePlanner\Creator\TileLengthRangeCreator;
 use TilePlanner\TilePlanner\Creator\TileLengthRangeCreatorInterface;
+use TilePlanner\TilePlanner\Models\TileCounter;
 use TilePlanner\TilePlanner\TilePlannerConstants;
 use TilePlanner\TilePlanner\Models\TilePlan;
 use TilePlanner\TilePlanner\Models\TilePlanInput;
@@ -59,7 +60,11 @@ final class TileFromRestCreator implements FirstTileCreatorInterface
                 ) {
                     $rests->removeRest($restLength, TilePlannerConstants::RESTS_LEFT);
 
-                    return Tile::create($tileInput->getTileWidth(), $restLength, $rest->getNumber());
+                    return Tile::create(
+                        $tileInput->getTileWidth(),
+                        $restLength,
+                        $rest->getNumber()
+                    );
                 }
             }
 
@@ -79,7 +84,11 @@ final class TileFromRestCreator implements FirstTileCreatorInterface
 
                 $rests->addThrash($trash);
 
-                return Tile::create($tileInput->getTileWidth(), $maxLengthOfFirstRange);
+                return Tile::create(
+                    $tileInput->getTileWidth(),
+                    $maxLengthOfFirstRange,
+                    TileCounter::next(),
+                );
             }
         }
 

--- a/src/TilePlanner/Creator/FirstTileLengthCreator.php
+++ b/src/TilePlanner/Creator/FirstTileLengthCreator.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace TilePlanner\TilePlanner\Creator;
 
 use TilePlanner\TilePlanner\Creator\FirstTileCreator\FirstTileCreatorInterface;
+use TilePlanner\TilePlanner\Models\TileCounter;
 use TilePlanner\TilePlanner\Models\TilePlan;
 use TilePlanner\TilePlanner\Models\TilePlanInput;
 use TilePlanner\TilePlanner\Models\LengthRangeBag;
@@ -35,6 +36,10 @@ final class FirstTileLengthCreator implements FirstTileLengthCreatorInterface
             }
         }
 
-        return Tile::create($tileInput->getTileWidth(), $tileLength);
+        return Tile::create(
+            $tileInput->getTileWidth(),
+            $tileLength,
+            TileCounter::next()
+        );
     }
 }

--- a/src/TilePlanner/Creator/LastTileCreator/LastTileFittingCreator.php
+++ b/src/TilePlanner/Creator/LastTileCreator/LastTileFittingCreator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace TilePlanner\TilePlanner\Creator\LastTileCreator;
 
+use TilePlanner\TilePlanner\Models\TileCounter;
 use TilePlanner\TilePlanner\TilePlannerConstants;
 use TilePlanner\TilePlanner\Models\TilePlan;
 use TilePlanner\TilePlanner\Models\TilePlanInput;
@@ -17,7 +18,11 @@ final class LastTileFittingCreator implements LastTileCreatorInterface
         $restOfRow = $tileInput->getRoomWidth() - $usedRowLength;
         $restOfTile = $tileInput->getTileLength() - $restOfRow;
 
-        $tile = Tile::create($tileInput->getTileWidth(), $restOfRow);
+        $tile = Tile::create(
+            $tileInput->getTileWidth(),
+            $restOfRow,
+            TileCounter::next()
+        );
 
         $rests->addRest(
             $restOfTile,

--- a/src/TilePlanner/Creator/LastTileCreator/LastTileFromRestCreator.php
+++ b/src/TilePlanner/Creator/LastTileCreator/LastTileFromRestCreator.php
@@ -19,7 +19,11 @@ final class LastTileFromRestCreator implements LastTileCreatorInterface
         $foundRest = $this->findTileInRests($restOfRow, $rests);
 
         if ($foundRest !== null) {
-            return Tile::create($tileInput->getTileWidth(), $foundRest->getLength(), $foundRest->getNumber());
+            return Tile::create(
+                $tileInput->getTileWidth(),
+                $foundRest->getLength(),
+                $foundRest->getNumber()
+            );
         }
 
         return null;

--- a/src/TilePlanner/Creator/LastTileCreator/LastTileFromRestForChessTypeCreator.php
+++ b/src/TilePlanner/Creator/LastTileCreator/LastTileFromRestForChessTypeCreator.php
@@ -19,7 +19,11 @@ final class LastTileFromRestForChessTypeCreator implements LastTileCreatorInterf
         $foundRest = $this->findTileInRests($restOfRow, $rests);
 
         if ($foundRest !== null) {
-            return Tile::create($tileInput->getTileWidth(), $foundRest->getLength(), $foundRest->getNumber());
+            return Tile::create(
+                $tileInput->getTileWidth(),
+                $foundRest->getLength(),
+                $foundRest->getNumber()
+            );
         }
 
         return null;

--- a/src/TilePlanner/Creator/LastTileLengthCreator.php
+++ b/src/TilePlanner/Creator/LastTileLengthCreator.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace TilePlanner\TilePlanner\Creator;
 
 use TilePlanner\TilePlanner\Creator\LastTileCreator\LastTileCreatorInterface;
+use TilePlanner\TilePlanner\Models\TileCounter;
 use TilePlanner\TilePlanner\Models\TilePlan;
 use TilePlanner\TilePlanner\Models\TilePlanInput;
 use TilePlanner\TilePlanner\Models\Rests;
@@ -38,6 +39,10 @@ final class LastTileLengthCreator implements LastTileLengthCreatorInterface
             }
         }
 
-        return Tile::create($tileInput->getTileWidth(), $tileLength);
+        return Tile::create(
+            $tileInput->getTileWidth(),
+            $tileLength,
+            TileCounter::next()
+        );
     }
 }

--- a/src/TilePlanner/Creator/RowCreator.php
+++ b/src/TilePlanner/Creator/RowCreator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace TilePlanner\TilePlanner\Creator;
 
+use TilePlanner\TilePlanner\Models\TileCounter;
 use TilePlanner\TilePlanner\Models\TilePlan;
 use TilePlanner\TilePlanner\Models\TilePlanInput;
 use TilePlanner\TilePlanner\Models\Rests;
@@ -101,6 +102,7 @@ final class RowCreator implements RowCreatorInterface
         return Tile::create(
             $width,
             $length,
+            TileCounter::next()
         );
     }
 

--- a/src/TilePlanner/Models/Tile.php
+++ b/src/TilePlanner/Models/Tile.php
@@ -8,8 +8,6 @@ use JsonSerializable;
 
 final class Tile implements JsonSerializable
 {
-    private static int $numberCounter = 1;
-
     public static function create(float $width, float $length, ?int $number = null): self
     {
         return new self($width, $length, $number);
@@ -18,13 +16,8 @@ final class Tile implements JsonSerializable
     private function __construct(
         private float $width,
         private float $length,
-        private ?int $number = null
-    ) {
-        if ($number == null) {
-            $this->number = self::$numberCounter;
-            self::$numberCounter++;
-        }
-    }
+        private ?int $number
+    ) {}
 
     public function getWidth(): float
     {
@@ -36,7 +29,7 @@ final class Tile implements JsonSerializable
         return $this->length;
     }
 
-    public function getNumber(): int
+    public function getNumber(): ?int
     {
         return $this->number;
     }

--- a/src/TilePlanner/Models/TileCounter.php
+++ b/src/TilePlanner/Models/TileCounter.php
@@ -15,7 +15,7 @@ final class TileCounter
         return self::$numberCounter;
     }
 
-    public function current(): int
+    public static function current(): int
     {
         return self::$numberCounter;
     }

--- a/src/TilePlanner/Models/TileCounter.php
+++ b/src/TilePlanner/Models/TileCounter.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TilePlanner\TilePlanner\Models;
+
+final class TileCounter
+{
+    private static int $numberCounter = 0;
+
+    public static function next(): int
+    {
+        self::$numberCounter++;
+
+        return self::$numberCounter;
+    }
+
+    public function current(): int
+    {
+        return self::$numberCounter;
+    }
+}

--- a/tests/Unit/TilePlanner/Creator/RowCreatorTest.php
+++ b/tests/Unit/TilePlanner/Creator/RowCreatorTest.php
@@ -11,6 +11,7 @@ use TilePlanner\TilePlanner\Creator\RowCreator;
 use TilePlanner\TilePlanner\Models\LayingOptions;
 use TilePlanner\TilePlanner\Models\Room;
 use TilePlanner\TilePlanner\Models\Row;
+use TilePlanner\TilePlanner\Models\TileCounter;
 use TilePlanner\TilePlanner\Models\TilePlan;
 use TilePlanner\TilePlanner\Models\TilePlanInput;
 use TilePlanner\TilePlanner\Models\Rests;
@@ -26,12 +27,12 @@ final class RowCreatorTest extends TestCase
         $firstTileLengthCalculator = $this->createMock(FirstTileLengthCreatorInterface::class);
         $firstTileLengthCalculator
             ->method('create')
-            ->willReturn(Tile::create(15, 25));
+            ->willReturn(Tile::create(20, 120, 1));
 
         $lastTileLengthCalculator = $this->createMock(LastTileLengthCreatorInterface::class);
         $lastTileLengthCalculator
             ->method('create')
-            ->willReturn(Tile::create(15, 25));
+            ->willReturn(Tile::create(20, 120, 1));
 
         $this->creator = new RowCreator($firstTileLengthCalculator, $lastTileLengthCalculator);
     }
@@ -43,13 +44,12 @@ final class RowCreatorTest extends TestCase
 
         $tileInput = new TilePlanInput(
             Room::create(200, 100),
-            Tile::create(20, 50),
+            Tile::create(20, 120),
             new LayingOptions(0)
         );
 
         $actualRow = $this->creator->createRow($tileInput, $plan, $rest);
-
-        self::assertCount(5, $actualRow->getTiles());
+        self::assertCount(2, $actualRow->getTiles());
     }
 
     public function test_row_has_same_with_as_tile(): void
@@ -84,5 +84,21 @@ final class RowCreatorTest extends TestCase
         $actualRow = $this->creator->createRow($tileInput, $plan, $rest);
 
         $this->assertEquals(10, $actualRow->getWidth());
+    }
+
+    public function test_first_tile_of_row_has_number_one(): void
+    {
+        $plan = new TilePlan();
+        $rest = new Rests();
+
+        $tileInput = new TilePlanInput(
+            Room::create(450, 330),
+            Tile::create(20, 120),
+            new LayingOptions(30)
+        );
+
+        $actualRow = $this->creator->createRow($tileInput, $plan, $rest);
+
+        $this->assertEquals(1, $actualRow->getTiles()[0]->getNumber());
     }
 }

--- a/tests/Unit/TilePlanner/Models/TileCounterTest.php
+++ b/tests/Unit/TilePlanner/Models/TileCounterTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TilePlannerTests\Unit\TilePlanner\Models;
+
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use TilePlanner\TilePlanner\Models\TileCounter;
+
+final class TileCounterTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $reflection = new ReflectionClass(TileCounter::class);
+        $reflection->setStaticPropertyValue('numberCounter', 0);
+    }
+
+    public function test_counter_is_0_when_not_incremented(): void
+    {
+        $this->assertEquals(0, TileCounter::current());
+    }
+
+    public function test_counter_is_1_after_incrementing_once(): void
+    {
+        TileCounter::next();
+
+        $this->assertEquals(1, TileCounter::current());
+    }
+
+    public function test_counter_is_5_after_incrementing_five_times(): void
+    {
+        for ($i = 1; $i <= 5; $i++) {
+            TileCounter::next();
+        }
+
+        $this->assertEquals(5, TileCounter::current());
+    }
+}

--- a/tests/Unit/TilePlanner/TilePlanCreatorTest.php
+++ b/tests/Unit/TilePlanner/TilePlanCreatorTest.php
@@ -23,7 +23,7 @@ final class TilePlanCreatorTest extends TestCase
         $rowCreator = $this->createStub(RowCreatorInterface::class);
         $rowCreator->method('createRow')->willReturn(
             (new Row())
-                ->addTile(Tile::create(25, 100))
+                ->addTile(Tile::create(25, 100, 10))
         );
 
         $rests = new Rests();


### PR DESCRIPTION
**background**:
user stated that numbers are not correct, e.g. starts with 2 and not 1
problem: tile class is mutable and used for generating the tiles but also to initialise the room. this will count the first tile and increase counter.

**changes**:
make tile class immutable and create new mutable tile-counter as a dependency