### PR TITLE
fix rests: dont remove all of same length

### DIFF
--- a/src/TilePlanner/Models/Rests.php
+++ b/src/TilePlanner/Models/Rests.php
@@ -46,6 +46,7 @@ final class Rests
         foreach (self::$rest[$side] as $key => $rest) {
             if ($rest->getLength() === $length) {
                 unset(self::$rest[$side][$key]);
+
                 break;
             }
         }
@@ -79,7 +80,8 @@ final class Rests
 
     private function totalLengthOfRestsFromSide(string $side): float
     {
-        return array_sum(array_map(static function(Rest $rest) {
+        return array_sum(
+            array_map(static function (Rest $rest) {
                 return $rest->getLength();
             }, $this->getRests($side))
         );

--- a/src/TilePlanner/Models/Rests.php
+++ b/src/TilePlanner/Models/Rests.php
@@ -46,6 +46,7 @@ final class Rests
         foreach (self::$rest[$side] as $key => $rest) {
             if ($rest->getLength() === $length) {
                 unset(self::$rest[$side][$key]);
+                break;
             }
         }
 
@@ -69,8 +70,18 @@ final class Rests
         return self::$trash;
     }
 
-    public function sumOfAll(): float
+    public function totalLengthOfAllRests(): float
     {
-        return array_sum($this->getRests(TilePlannerConstants::RESTS_LEFT)) + array_sum($this->getRests(TilePlannerConstants::RESTS_RIGHT)) + array_sum($this->getTrash());
+        return $this->totalLengthOfRestsFromSide(TilePlannerConstants::RESTS_LEFT)
+            + $this->totalLengthOfRestsFromSide(TilePlannerConstants::RESTS_RIGHT)
+            + array_sum($this->getTrash());
+    }
+
+    private function totalLengthOfRestsFromSide(string $side): float
+    {
+        return array_sum(array_map(static function(Rest $rest) {
+                return $rest->getLength();
+            }, $this->getRests($side))
+        );
     }
 }

--- a/src/TilePlanner/TilePlanCreator.php
+++ b/src/TilePlanner/TilePlanCreator.php
@@ -49,7 +49,7 @@ final class TilePlanCreator
                 $this->rests->getRests(TilePlannerConstants::RESTS_RIGHT)
             )
         );
-        $plan->setTotalRest($this->rests->sumOfAll());
+        $plan->setTotalRest($this->rests->totalLengthOfAllRests());
 
         return $plan;
     }

--- a/tests/Unit/TilePlanner/Models/RestsTest.php
+++ b/tests/Unit/TilePlanner/Models/RestsTest.php
@@ -63,5 +63,6 @@ final class RestsTest extends TestCase
             TilePlannerConstants::RESTS_LEFT => [],
             TilePlannerConstants::RESTS_RIGHT => []
         ]);
+        $reflection->setStaticPropertyValue('trash', []);
     }
 }

--- a/tests/Unit/TilePlanner/Models/RestsTest.php
+++ b/tests/Unit/TilePlanner/Models/RestsTest.php
@@ -11,13 +11,10 @@ use TilePlanner\TilePlanner\TilePlannerConstants;
 
 final class RestsTest extends TestCase
 {
-    public function setUp(): void
-    {
-        $this->resetRests();
-    }
-
     public function test_removing_one_rest_should_not_remove_all(): void
     {
+        $this->resetRests();
+
         $rests = new Rests();
 
         $rests->addRest(90, 30, TilePlannerConstants::RESTS_LEFT, 1);
@@ -33,6 +30,8 @@ final class RestsTest extends TestCase
 
     public function test_sum_all_rests(): void
     {
+        $this->resetRests();
+
         $rests = new Rests();
 
         $rests->addRest(40, 20, TilePlannerConstants::RESTS_LEFT, 1);
@@ -47,6 +46,8 @@ final class RestsTest extends TestCase
 
     public function test_rest_is_trash_when_smaller_then_min_length(): void
     {
+        $this->resetRests();
+
         $rests = new Rests();
 
         $rests->addRest(20, 30, TilePlannerConstants::RESTS_LEFT, 1);

--- a/tests/Unit/TilePlanner/Models/RestsTest.php
+++ b/tests/Unit/TilePlanner/Models/RestsTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TilePlannerTests\Unit\TilePlanner\Models;
+
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use TilePlanner\TilePlanner\Models\Rests;
+use TilePlanner\TilePlanner\TilePlannerConstants;
+
+final class RestsTest extends TestCase
+{
+    public function setUp(): void
+    {
+        $this->resetRests();
+    }
+
+    public function test_removing_one_rest_should_not_remove_all(): void
+    {
+        $rests = new Rests();
+
+        $rests->addRest(90, 30, TilePlannerConstants::RESTS_LEFT, 1);
+        $rests->addRest(90, 30, TilePlannerConstants::RESTS_LEFT, 2);
+
+        $rests->removeRest(90, TilePlannerConstants::RESTS_LEFT);
+
+        $remainingRests = $rests->getRests(TilePlannerConstants::RESTS_LEFT);
+
+        $this->assertCount(1, $remainingRests);
+        $this->assertEquals(90, current($remainingRests)->getLength());
+    }
+
+    public function test_sum_all_rests(): void
+    {
+        $rests = new Rests();
+
+        $rests->addRest(40, 20, TilePlannerConstants::RESTS_LEFT, 1);
+        $rests->addRest(30, 20, TilePlannerConstants::RESTS_LEFT, 2);
+        $rests->addRest(20, 20, TilePlannerConstants::RESTS_RIGHT, 3);
+        $rests->addThrash(10);
+
+        $this->assertTrue($rests->hasRest(TilePlannerConstants::RESTS_LEFT));
+        $this->assertTrue($rests->hasRest(TilePlannerConstants::RESTS_RIGHT));
+        $this->assertEquals(100, $rests->totalLengthOfAllRests());
+    }
+
+    public function test_rest_is_trash_when_smaller_then_min_length(): void
+    {
+        $rests = new Rests();
+
+        $rests->addRest(20, 30, TilePlannerConstants::RESTS_LEFT, 1);
+
+        $this->assertFalse($rests->hasRest(TilePlannerConstants::RESTS_LEFT));
+        $this->assertNotEmpty($rests->getTrash());
+    }
+
+    private function resetRests(): void
+    {
+        $reflection = new ReflectionClass(Rests::class);
+        $reflection->setStaticPropertyValue('rest', [
+            TilePlannerConstants::RESTS_LEFT => [],
+            TilePlannerConstants::RESTS_RIGHT => []
+        ]);
+    }
+}


### PR DESCRIPTION
bug: when using a rest for a tile it removes all rests of same length instead of one.

- add break when first matching rest was removed
- test coverage